### PR TITLE
Switch from Imagen3 to Stability API

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,10 @@
 
         // API 키 설정
         const GEMINI_API_KEY = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI"; // Google Gemini API 키
+        const STABILITY_API_KEY = "YOUR_STABILITY_API_KEY"; // Stability API 키
 
         const TEXT_MODEL = "gemini-2.0-flash";
-        const IMAGE_MODEL = "imagen3";
+        const STABILITY_ENGINE = "stable-diffusion-v1-5"; // Stability 엔진 ID
 
         // 활동지 생성 메인 함수
         async function generateWorksheet() {
@@ -206,7 +207,7 @@
             return JSON.parse(result.candidates[0].content.parts[0].text);
         }
         
-        // Gemini Imagen3 API로 이미지 생성
+        // Stability AI API로 이미지 생성
         async function generateImageForParagraph(paragraphText) {
             // 1. Gemini API를 사용하여 한글 문단을 영어로 번역합니다.
             const translationPrompt = `Translate the following Korean text to English for an image generation prompt. Make it a simple, descriptive phrase. Korean text: "${paragraphText}"`;
@@ -235,32 +236,39 @@
             // 2. 번역된 영어 텍스트로 이미지 생성 프롬프트를 만듭니다.
             const imagePrompt = `A very cute and simple children's book illustration, in the style of a cartoon, bright and soft colors, about: "${englishDescription}"`;
             
-            // 3. Google Gemini Imagen3 모델을 호출합니다.
+            // 3. Stability AI 텍스트-투-이미지 API를 호출합니다.
             const payload = {
-                contents: [{ role: "user", parts: [{ text: imagePrompt }] }]
+                text_prompts: [{ text: imagePrompt }],
+                cfg_scale: 7,
+                height: 512,
+                width: 512,
+                samples: 1,
+                steps: 30
             };
-            const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${IMAGE_MODEL}:generateContent?key=${GEMINI_API_KEY}`, {
+            const response = await fetch(`https://api.stability.ai/v1/generation/${STABILITY_ENGINE}/text-to-image`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'Authorization': `Bearer ${STABILITY_API_KEY}`
+                },
                 body: JSON.stringify(payload)
             });
 
             if (!response.ok) {
-                 const errorBody = await response.text();
-                 console.error("이미지 생성 API 응답 오류:", errorBody);
-                 throw new Error(`이미지 생성 API 오류: ${response.status} ${response.statusText}`);
+                const errorBody = await response.text();
+                console.error("이미지 생성 API 응답 오류:", errorBody);
+                throw new Error(`이미지 생성 API 오류: ${response.status} ${response.statusText}`);
             }
 
             const responseJSON = await response.json();
-
-            const imageData = responseJSON.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
-            const mimeType = responseJSON.candidates?.[0]?.content?.parts?.[0]?.inlineData?.mimeType;
-            if (!imageData || !mimeType) {
-                 console.error("잘못된 이미지 API 응답 형식:", responseJSON);
-                 throw new Error("이미지 생성 API로부터 유효한 데이터를 받지 못했습니다.");
+            const imageData = responseJSON.artifacts?.[0]?.base64;
+            if (!imageData) {
+                console.error("잘못된 이미지 API 응답 형식:", responseJSON);
+                throw new Error("이미지 생성 API로부터 유효한 데이터를 받지 못했습니다.");
             }
 
-            return `data:${mimeType};base64,${imageData}`;
+            return `data:image/png;base64,${imageData}`;
         }
 
         async function generateQuestions(fullText) {


### PR DESCRIPTION
## Summary
- update worksheet generator to call Stability's text-to-image API

## Testing
- `python3 - <<'EOF'
import sys, html.parser
class TestParser(html.parser.HTMLParser):
    def error(self, message):
        print('HTML parse error:', message)
parser=TestParser()
with open('index.html', 'r') as f:
    data=f.read()
parser.feed(data)
print('HTML parsed successfully')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684ac73f184c832e88c61863ef0a452a