### PR TITLE
Add per-word and paragraph TTS

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,19 @@
             height: 60px;
             animation: spin 2s linear infinite;
         }
+        .tts-word-wrapper {
+            position: relative;
+            display: inline-block;
+        }
+        .word-tts-bar {
+            position: absolute;
+            top: -4px;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background-color: #60a5fa; /* blue-400 */
+            cursor: pointer;
+        }
         @keyframes spin {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
@@ -119,8 +132,9 @@
                 const paragraphPromises = paragraphs.map(async (p, index) => {
                     const imageUrl = await generateImageForParagraph(p);
                     return `
-                        <div class="paragraph-block mb-8">
-                            <p class="text-lg md:text-xl leading-relaxed bg-gray-50 p-4 rounded-lg"><strong>[${index + 1}문단]</strong> ${p}</p>
+                        <div class="paragraph-block mb-8 relative">
+                            <button class="paragraph-tts absolute -left-8 top-4 bg-blue-600 hover:bg-blue-700 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs">&#9654;</button>
+                            <p class="text-lg md:text-xl leading-relaxed bg-gray-50 p-4 rounded-lg"><strong>[${index + 1}문단]</strong> ${wrapWordsForTTS(p)}</p>
                             <div class="flex justify-center my-4">
                                 <img src="${imageUrl}" alt="${topic} 관련 이미지 ${index + 1}" class="rounded-lg shadow-md max-w-sm w-full h-auto border-4 border-white">
                             </div>
@@ -348,6 +362,33 @@
                 downloadButton.classList.remove('invisible');
             });
         }
+
+        // ====================== TTS 기능 =========================
+        function speakText(text) {
+            if (!text) return;
+            const utterance = new SpeechSynthesisUtterance(text);
+            utterance.lang = 'ko-KR';
+            speechSynthesis.cancel();
+            speechSynthesis.speak(utterance);
+        }
+
+        function wrapWordsForTTS(text) {
+            return text.split(/(\s+)/).map(token => {
+                if (token.trim() === '') return token;
+                const escaped = token.replace(/"/g, '&quot;');
+                return `<span class="tts-word-wrapper" data-word="${escaped}"><span class="word-tts-bar"></span>${token}</span>`;
+            }).join('');
+        }
+
+        worksheetArea.addEventListener('click', (e) => {
+            if (e.target.classList.contains('word-tts-bar')) {
+                const word = e.target.parentElement.dataset.word;
+                speakText(word);
+            } else if (e.target.classList.contains('paragraph-tts')) {
+                const paragraph = e.target.closest('.paragraph-block').querySelector('p').innerText.replace(/\[[0-9]+문단\]\s*/, '');
+                speakText(paragraph);
+            }
+        });
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- add CSS for word-level TTS overlays
- wrap generated words with clickable TTS bars
- include paragraph play button for each block
- implement JavaScript to handle TTS playback
- remove old selection-based button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad2a8a064832ea8130ee5d46cbd65