### PR TITLE
Add interactive word and paragraph TTS features

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,38 @@
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
+        /* 단어별 TTS 막대와 문단 전체 읽기 버튼 스타일 */
+        .tts-word {
+            position: relative;
+            display: inline-block;
+            padding-top: 4px;
+            margin-right: 2px;
+            cursor: pointer;
+        }
+        .tts-word::before {
+            content: "";
+            position: absolute;
+            top: -4px;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background-color: #3b82f6;
+        }
+        .paragraph-tts {
+            position: absolute;
+            left: -1.75rem;
+            top: 0.5rem;
+            width: 1.5rem;
+            height: 1.5rem;
+            background-color: #3b82f6;
+            color: white;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body class="p-4 md:p-8">
@@ -121,9 +153,11 @@
 
                 const paragraphPromises = paragraphs.map(async (p, index) => {
                     const imageUrl = await generateImageForParagraph(p);
+                    const wordSpans = p.split(/\s+/).map(w => `<span class="tts-word">${w}</span>`).join(' ');
                     return `
-                        <div class="paragraph-block mb-8">
-                            <p class="text-lg md:text-xl leading-relaxed bg-gray-50 p-4 rounded-lg"><strong>[${index + 1}문단]</strong> ${p}</p>
+                        <div class="paragraph-block mb-8 relative">
+                            <button class="paragraph-tts" data-text="${p}">&#9654;</button>
+                            <p class="text-lg md:text-xl leading-relaxed bg-gray-50 p-4 rounded-lg"><strong>[${index + 1}문단]</strong> ${wordSpans}</p>
                             <div class="flex justify-center my-4">
                                 <img src="${imageUrl}" alt="${topic} 관련 이미지 ${index + 1}" class="rounded-lg shadow-md max-w-sm w-full h-auto border-4 border-white">
                             </div>
@@ -385,6 +419,25 @@
                 speechSynthesis.speak(utterance);
             }
             ttsButton.classList.add('hidden');
+        });
+        document.addEventListener('click', (e) => {
+            if (e.target.classList.contains('tts-word')) {
+                const text = e.target.textContent.trim();
+                if (text) {
+                    const utterance = new SpeechSynthesisUtterance(text);
+                    utterance.lang = 'ko-KR';
+                    speechSynthesis.cancel();
+                    speechSynthesis.speak(utterance);
+                }
+            } else if (e.target.classList.contains('paragraph-tts')) {
+                const text = e.target.getAttribute('data-text');
+                if (text) {
+                    const utterance = new SpeechSynthesisUtterance(text);
+                    utterance.lang = 'ko-KR';
+                    speechSynthesis.cancel();
+                    speechSynthesis.speak(utterance);
+                }
+            }
         });
     </script>
 


### PR DESCRIPTION
## Summary
- style word-level bar and paragraph TTS button
- break each paragraph into clickable word spans
- add a button beside each paragraph to read it aloud
- add event listener to handle word and paragraph reading

## Testing
- `npx --yes eslint index.html` *(fails: ESLint config missing)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684ad55ec5e4832ea175751b12e1f078