### PR TITLE
Add in-page article list popup with author field

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <div class="max-w-4xl mx-auto bg-white rounded-2xl shadow-lg p-6 md:p-10">
 
         <div class="text-right mb-4">
-            <a href="list.html" class="text-blue-600 underline">글 목록</a>
+            <button id="open-list" class="w-full md:w-auto bg-teal-600 hover:bg-teal-700 text-white font-bold py-2 px-4 rounded-lg transition-transform transform hover:scale-105">글 목록</button>
         </div>
 
         <!-- 제목 -->
@@ -128,6 +128,16 @@
             </button>
         </div>
 
+        <!-- 글 목록 팝업 -->
+        <div id="list-popup" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+            <div class="bg-white rounded-xl w-11/12 md:w-3/4 max-h-screen p-6 overflow-y-auto">
+                <div class="text-right mb-4">
+                    <button id="close-list" class="text-gray-600">닫기</button>
+                </div>
+                <ul id="article-list" class="space-y-2"></ul>
+            </div>
+        </div>
+
     </div>
 
     <script>
@@ -138,6 +148,8 @@
         const errorMessage = document.getElementById('error-message');
         const worksheetArea = document.getElementById('worksheet-area');
         const actionButtons = document.getElementById('action-buttons');
+        const listPopup = document.getElementById('list-popup');
+        const articleList = document.getElementById('article-list');
         const generateBtn = document.getElementById('generate-btn');
 
         // API 키 설정
@@ -195,6 +207,11 @@
                 });
                 questionsHTML += `</ol></div>`;
                 worksheetArea.innerHTML += questionsHTML;
+                worksheetArea.innerHTML += `
+                    <div class="mt-6">
+                        <label class="font-semibold text-gray-700 mr-2">작성자 이름:</label>
+                        <input type="text" id="author" class="border p-2 rounded-lg" placeholder="이름" />
+                    </div>`;
 
                 actionButtons.classList.remove('hidden');
 
@@ -409,8 +426,9 @@
             const title = titleElem ? titleElem.textContent.replace(/\[|\]/g, '') : '';
             const html = worksheetArea.innerHTML;
             const answers = Array.from(document.querySelectorAll('.questions textarea')).map(el => el.value);
+            const author = document.getElementById('author')?.value || '';
 
-            const data = { topic, wordCount, title, html, answers, updatedAt: firebase.firestore.FieldValue.serverTimestamp() };
+            const data = { topic, wordCount, title, html, answers, author, updatedAt: firebase.firestore.FieldValue.serverTimestamp() };
 
             try {
                 if (id) {
@@ -436,12 +454,47 @@
                     document.getElementById('topic').value = data.topic || '';
                     document.getElementById('word_count').value = data.wordCount || '';
                     worksheetArea.innerHTML = data.html || '';
+                    const textareas = worksheetArea.querySelectorAll('.questions textarea');
+                    textareas.forEach((el, idx) => { el.value = data.answers?.[idx] || ''; });
+                    if (!worksheetArea.querySelector('#author')) {
+                        worksheetArea.insertAdjacentHTML('beforeend', `
+                            <div class="mt-6">
+                                <label class="font-semibold text-gray-700 mr-2">작성자 이름:</label>
+                                <input type="text" id="author" class="border p-2 rounded-lg" placeholder="이름" />
+                            </div>`);
+                    }
+                    const authorInput = document.getElementById('author');
+                    if (authorInput) authorInput.value = data.author || '';
                     actionButtons.classList.remove('hidden');
                 }
             } catch (err) {
                 console.error('불러오기 오류:', err);
             }
         }
+
+        async function openListPopup() {
+            listPopup.classList.remove('hidden');
+            articleList.innerHTML = '';
+            const snapshot = await db.collection('articles').orderBy('updatedAt', 'desc').get();
+            snapshot.forEach(doc => {
+                const data = doc.data();
+                const li = document.createElement('li');
+                li.className = 'border-b pb-2 cursor-pointer hover:bg-gray-100';
+                const date = data.updatedAt?.toDate().toLocaleDateString('ko-KR') || '';
+                li.innerHTML = `<span class="font-semibold">${data.title || '제목 없음'}</span> - ${date} - ${data.author || ''}`;
+                li.addEventListener('click', () => {
+                    window.location.search = '?id=' + doc.id;
+                });
+                articleList.appendChild(li);
+            });
+        }
+
+        function closeListPopup() {
+            listPopup.classList.add('hidden');
+        }
+
+        document.getElementById('open-list').addEventListener('click', openListPopup);
+        document.getElementById('close-list').addEventListener('click', closeListPopup);
 
         document.addEventListener('DOMContentLoaded', loadArticleForEdit);
 

--- a/list.html
+++ b/list.html
@@ -15,12 +15,16 @@
             const list = document.getElementById('article-list');
             const snapshot = await db.collection('articles').orderBy('updatedAt', 'desc').get();
             snapshot.forEach(doc => {
+                const data = doc.data();
                 const li = document.createElement('li');
+                li.className = 'border-b pb-2';
+                const date = data.updatedAt?.toDate().toLocaleDateString('ko-KR') || '';
                 const a = document.createElement('a');
                 a.href = `index.html?id=${doc.id}`;
                 a.className = 'text-blue-600 underline';
-                a.textContent = doc.data().title || '제목 없음';
+                a.textContent = data.title || '제목 없음';
                 li.appendChild(a);
+                li.appendChild(document.createTextNode(` - ${date} - ${data.author || ''}`));
                 list.appendChild(li);
             });
         }


### PR DESCRIPTION
## Summary
- add `작성자 이름` input to worksheet and save it with articles
- keep answers when loading an article
- show list of articles in a popup on the homepage
- display title, date, and author in both the popup and list page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ba513d888832e8057c89a1df55787