### PR TITLE
Enable TTS playback for questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,21 @@
             font-size: 0.75rem;
             cursor: pointer;
         }
+        .question-tts {
+            position: absolute;
+            left: -1.75rem;
+            top: 0.25rem;
+            width: 1.5rem;
+            height: 1.5rem;
+            background-color: #3b82f6;
+            color: white;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body class="p-4 md:p-8">
@@ -179,7 +194,13 @@
                         <ol class="list-decimal list-inside space-y-3 text-lg text-gray-800">
                 `;
                 questions.forEach(q => {
-                    questionsHTML += `<li><p>${q}</p><textarea class="mt-2 w-full p-2 border border-gray-300 rounded-lg" rows="2" placeholder="답을 적어 보세요..."></textarea></li>`;
+                    const qWords = q.split(/\s+/).map(w => `<span class="tts-word">${w}</span>`).join(' ');
+                    questionsHTML += `
+                        <li class="relative">
+                            <button class="question-tts" data-text="${q}">&#9654;</button>
+                            <p>${qWords}</p>
+                            <textarea class="mt-2 w-full p-2 border border-gray-300 rounded-lg" rows="2" placeholder="답을 적어 보세요..."></textarea>
+                        </li>`;
                 });
                 questionsHTML += `</ol></div>`;
                 worksheetArea.innerHTML += questionsHTML;
@@ -438,6 +459,14 @@
                     speechSynthesis.speak(utterance);
                 }
             } else if (e.target.classList.contains('paragraph-tts')) {
+                const text = e.target.getAttribute('data-text');
+                if (text) {
+                    const utterance = new SpeechSynthesisUtterance(text);
+                    utterance.lang = 'ko-KR';
+                    speechSynthesis.cancel();
+                    speechSynthesis.speak(utterance);
+                }
+            } else if (e.target.classList.contains('question-tts')) {
                 const text = e.target.getAttribute('data-text');
                 if (text) {
                     const utterance = new SpeechSynthesisUtterance(text);


### PR DESCRIPTION
## Summary
- support TTS playback for the generated questions
- allow reading each question word-by-word or as a whole

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f742cc438832eb2f6c9d997de417f